### PR TITLE
fix: Reconcilation loop not working properly

### DIFF
--- a/internal/controller/appdeployment_controller.go
+++ b/internal/controller/appdeployment_controller.go
@@ -150,6 +150,7 @@ func (r *AppDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *AppDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&deskreev1.AppDeployment{}).
+		Owns(&appsv1.Deployment{}).
 		Named("appdeployment").
 		Complete(r)
 }


### PR DESCRIPTION
Adding`Owns(&appsv1.Deployment{})` to the controller setup, it will now watch for changes to Deployment resources that it owns (via owner references) and trigger reconciliation when those resources change

#1