### PR TITLE
Task3: Golang Backend for Kubernetes Deployment

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -100,7 +100,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		setupLog.Info("starting API server", "port", apiServerPort)
+		setupLog.Info("starting API server (apiserver)", "port", apiServerPort)
 		if err := server.Start(apiServerPort); err != nil {
 			setupLog.Error(err, "problem running API server")
 			os.Exit(1)

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2025 LuisEspinoza.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	deskreev1 "github.com/espinozasenior/go-assesstment.git/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+type Server struct {
+	client client.Client
+}
+
+type DeployRequest struct {
+	Image       string `json:"image"`
+	Name        string `json:"name"`
+	MemoryLimit string `json:"memoryLimit"`
+	MinReplicas int32  `json:"minReplicas"`
+	MaxReplicas int32  `json:"maxReplicas"`
+}
+
+type StatusResponse struct {
+	Status   string `json:"status"`
+	Replicas int32  `json:"replicas"`
+}
+
+func NewServer() (*Server, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error getting kubeconfig: %v", err)
+	}
+
+	scheme := scheme.Scheme
+	if err := deskreev1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("error adding deskree scheme: %v", err)
+	}
+
+	client, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %v", err)
+	}
+
+	return &Server{client: client}, nil
+}
+
+func (s *Server) Start(port int) error {
+	http.HandleFunc("/deploy", s.handleDeploy)
+	http.HandleFunc("/status/", s.handleStatus)
+	http.HandleFunc("/", s.handleDelete)
+
+	addr := fmt.Sprintf(":%d", port)
+	log.Printf("Server starting on %s", addr)
+	return http.ListenAndServe(addr, nil)
+}
+
+func (s *Server) handleDeploy(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req DeployRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	if req.Name == "" || req.Image == "" || req.MemoryLimit == "" {
+		http.Error(w, "Name, image, and memoryLimit are required", http.StatusBadRequest)
+		return
+	}
+
+	if req.MinReplicas <= 0 {
+		req.MinReplicas = 1
+	}
+
+	if req.MaxReplicas < req.MinReplicas {
+		req.MaxReplicas = req.MinReplicas
+	}
+
+	appDeployment := &deskreev1.AppDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.Name,
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       req.Name,
+				"app.kubernetes.io/managed-by": "go-assessment-api",
+			},
+		},
+		Spec: deskreev1.AppDeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": req.Name,
+				},
+			},
+			MemoryLimit: req.MemoryLimit,
+			MinReplicas: req.MinReplicas,
+			MaxReplicas: req.MaxReplicas,
+			Template: deskreev1.PodTemplateSpec{
+				ObjectMeta: deskreev1.ObjectMeta{
+					Labels: map[string]string{
+						"app": req.Name,
+					},
+				},
+				Spec: deskreev1.PodSpec{
+					Containers: []deskreev1.Container{
+						{
+							Name:  req.Name,
+							Image: req.Image,
+							Ports: []deskreev1.ContainerPort{
+								{
+									ContainerPort: 80,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := s.client.Create(context.Background(), appDeployment); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to create AppDeployment: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "✅ AppDeployment \"%s\" created.\n", req.Name)
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 {
+		http.Error(w, "Invalid path", http.StatusBadRequest)
+		return
+	}
+
+	name := pathParts[2]
+	if name == "" {
+		http.Error(w, "Name is required", http.StatusBadRequest)
+		return
+	}
+
+	appDeployment := &deskreev1.AppDeployment{}
+	if err := s.client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, appDeployment); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to get AppDeployment: %v", err), http.StatusNotFound)
+		return
+	}
+
+	response := StatusResponse{
+		Status:   appDeployment.Status.State,
+		Replicas: appDeployment.Status.AvailableReplicas,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 2 {
+		http.Error(w, "Invalid path", http.StatusBadRequest)
+		return
+	}
+
+	name := pathParts[1]
+	if name == "" {
+		http.Error(w, "Name is required", http.StatusBadRequest)
+		return
+	}
+
+	appDeployment := &deskreev1.AppDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+	}
+
+	if err := s.client.Delete(context.Background(), appDeployment); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to delete AppDeployment: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "AppDeployment \"%s\" deleted.\n", name)
+}

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -145,12 +145,23 @@ func (s *Server) handleDeploy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.client.Create(context.Background(), appDeployment); err != nil {
-		http.Error(w, fmt.Sprintf("Failed to create AppDeployment: %v", err), http.StatusInternalServerError)
+		response := map[string]string{
+			"status":  "error",
+			"message": fmt.Sprintf("Failed to create AppDeployment: %v", err),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(response)
 		return
 	}
 
+	response := map[string]string{
+		"status":  "success",
+		"message": fmt.Sprintf("Deployment CRD %s created", req.Name),
+	}
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "✅ AppDeployment \"%s\" created.\n", req.Name)
+	json.NewEncoder(w).Encode(response)
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -271,7 +271,9 @@ func (s *Server) HandleDeploy(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(response)
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			apiLog.Error(err, "Failed to encode error response")
+		}
 		return
 	}
 
@@ -281,7 +283,9 @@ func (s *Server) HandleDeploy(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		apiLog.Error(err, "Failed to encode success response")
+	}
 }
 
 func (s *Server) HandleStatus(w http.ResponseWriter, r *http.Request) {
@@ -329,7 +333,9 @@ func (s *Server) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		apiLog.Error(err, "Failed to encode status response")
+	}
 }
 
 func (s *Server) HandleDelete(w http.ResponseWriter, r *http.Request) {
@@ -369,5 +375,7 @@ func (s *Server) HandleDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "AppDeployment \"%s\" deleted.\n", name)
+	if _, err := fmt.Fprintf(w, "AppDeployment \"%s\" deleted.\n", name); err != nil {
+		apiLog.Error(err, "Failed to write delete response")
+	}
 }

--- a/internal/apiserver/test/server_test.go
+++ b/internal/apiserver/test/server_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025 LuisEspinoza.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v1 "github.com/espinozasenior/go-assesstment.git/api/v1"
+	"github.com/espinozasenior/go-assesstment.git/internal/apiserver"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestCacheHandlingAfterDelete tests that the cache is properly updated after a delete operation
+func TestCacheHandlingAfterDelete(t *testing.T) {
+	// Create a fake client with the AppDeployment scheme
+	scheme := runtime.NewScheme()
+	v1.AddToScheme(scheme)
+
+	// Create a test AppDeployment
+	appName := "test-app"
+	appDeployment := &v1.AppDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      appName,
+			Namespace: "default",
+		},
+		Status: v1.AppDeploymentStatus{
+			State:             "Running",
+			AvailableReplicas: 1,
+		},
+	}
+
+	// Create a fake client with the test AppDeployment
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(appDeployment).
+		Build()
+
+	// Create a server with the fake client
+	server := &apiserver.Server{
+		Client:          fakeClient,
+		DeploymentCache: make(map[string]*v1.AppDeployment),
+	}
+
+	// Add the AppDeployment to the cache
+	server.DeploymentCache[appName] = appDeployment
+
+	// Test 1: Verify the AppDeployment is in the cache
+	statusReq := httptest.NewRequest("GET", "/status/"+appName, nil)
+	statusRecorder := httptest.NewRecorder()
+
+	server.HandleStatus(statusRecorder, statusReq)
+
+	if statusRecorder.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, statusRecorder.Code)
+	}
+
+	var statusResp apiserver.StatusResponse
+	if err := json.NewDecoder(statusRecorder.Body).Decode(&statusResp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if statusResp.Status != "Running" || statusResp.Replicas != 1 {
+		t.Errorf("Expected status 'Running' with 1 replica, got status '%s' with %d replicas",
+			statusResp.Status, statusResp.Replicas)
+	}
+
+	// Test 2: Delete the AppDeployment
+	deleteReq := httptest.NewRequest("DELETE", "/"+appName, nil)
+	deleteRecorder := httptest.NewRecorder()
+
+	server.HandleDelete(deleteRecorder, deleteReq)
+
+	if deleteRecorder.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, deleteRecorder.Code)
+	}
+
+	// Test 3: Verify the AppDeployment is removed from the cache
+	// The API server should try to get it from the API and fail with NotFound
+	statusReq2 := httptest.NewRequest("GET", "/status/"+appName, nil)
+	statusRecorder2 := httptest.NewRecorder()
+
+	server.HandleStatus(statusRecorder2, statusReq2)
+
+	if statusRecorder2.Code != http.StatusNotFound {
+		t.Errorf("Expected status code %d, got %d", http.StatusNotFound, statusRecorder2.Code)
+	}
+
+	// Verify the AppDeployment is not in the cache
+	if _, exists := server.DeploymentCache[appName]; exists {
+		t.Errorf("AppDeployment should have been removed from cache after deletion")
+	}
+}

--- a/internal/apiserver/test/server_test.go
+++ b/internal/apiserver/test/server_test.go
@@ -33,7 +33,9 @@ import (
 func TestCacheHandlingAfterDelete(t *testing.T) {
 	// Create a fake client with the AppDeployment scheme
 	scheme := runtime.NewScheme()
-	v1.AddToScheme(scheme)
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add v1 scheme: %v", err)
+	}
 
 	// Create a test AppDeployment
 	appName := "test-app"

--- a/internal/controller/appdeployment_controller.go
+++ b/internal/controller/appdeployment_controller.go
@@ -150,6 +150,7 @@ func (r *AppDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *AppDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&deskreev1.AppDeployment{}).
+		Owns(&appsv1.Deployment{}).
 		Named("appdeployment").
 		Complete(r)
 }


### PR DESCRIPTION
## Golang Backend for Kubernetes Deployment
REST API in Golang that interfaces with a Kubernetes operator to manage application deployments. The implementation includes three endpoints:
  
  - `POST /deploy` : Accepts image, name, memoryLimit, minReplicas, maxReplicas and creates an AppDeployment CRD in Kubernetes
  - `GET /status/{name}` : Retrieves the status of a deployed application
  - `DELETE /{name}` : Removes a deployed application from the cluster

## Key features
### Watcher.Interface()
This  ensures that the API server can monitor and react to changes in AppDeployment resources in real-time by deployment group, 

The implementation includes:

1. Added a watch.Interface and stopCh channel to the Server struct to manage the watcher lifecycle
2. Created a setupWatcher method that initializes a dynamic client to watch for AppDeployment resources
3. Implemented a watchEvents go-routine that processes events from the watchers result channel
4. Event type handling for Added, Modified, Deleted, and Error events and saved into a cache structure consumed by /status endpoint
5. Implemented automatic watcher restart if the channel closes unexpectedly

## Examples

#### POST
<img width="565" alt="image" src="https://github.com/user-attachments/assets/c8060e2d-26af-4013-a8bc-956e4569b0bd" />

#### GET
<img width="368" alt="image" src="https://github.com/user-attachments/assets/1a6c34cb-912d-411f-9afc-fa2a12868898" />

#### DELETE
<img width="369" alt="image" src="https://github.com/user-attachments/assets/aec6a5e6-6761-49a3-9fe7-dada62ca4ad9" />
